### PR TITLE
Adjust project registration modal dimensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,8 +218,8 @@
     </main>
 
     <!-- Modal para Adicionar/Editar Projeto -->
-    <div id="project-modal" class="fixed inset-0 bg-black bg-opacity-80 flex justify-center items-start overflow-y-auto hidden z-50 p-4 pt-16">
-        <div class="bg-[#1E2A47] p-8 rounded-xl w-full max-w-7xl transform transition-all scale-95 opacity-0" id="project-modal-content">
+    <div id="project-modal" class="fixed inset-0 bg-black bg-opacity-80 flex justify-center items-center overflow-y-auto hidden z-50 p-4 pt-16">
+        <div class="bg-[#1E2A47] p-6 md:p-8 rounded-xl w-full max-w-5xl lg:max-w-6xl 2xl:max-w-7xl max-h-[85vh] overflow-y-auto transform transition-all scale-95 opacity-0" id="project-modal-content">
             <div class="flex justify-between items-center mb-6"><h3 id="project-modal-title" class="text-2xl font-bold"></h3><button id="close-modal-btn" class="text-slate-400"><i data-lucide="x-circle"></i></button></div>
             <form id="project-form">
                 <input type="hidden" id="projectId">


### PR DESCRIPTION
## Summary
- center the project registration modal on screen and tweak padding for better balance
- constrain modal width responsively and limit its height to 85vh with internal scrolling to avoid overflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccc8f32a948328935239a386aeaa08