### PR TITLE
Add curated message suggestions and refine module ownership UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,8 +153,30 @@
                     <div class="overflow-x-auto"><table class="w-full text-left"><thead><tr class="border-b border-slate-700"><th class="p-3">Cliente / Projeto</th><th class="p-3">Status</th><th class="p-3">Progresso</th><th class="p-3">Ações</th></tr></thead><tbody id="projects-table-body"></tbody></table></div>
                 </div>
                 <div class="bg-[#1E2A47] p-6 rounded-xl">
-                     <h3 class="text-xl font-bold mb-4 flex items-center gap-2"><i data-lucide="trophy" class="text-yellow-400"></i> Gamificação da Equipe</h3>
-                    <div id="gamification-container" class="space-y-4 max-h-80 overflow-y-auto"></div>
+                    <h3 class="text-xl font-bold mb-2 flex items-center gap-2"><i data-lucide="settings-2" class="text-cyan-400"></i> Gestão Rápida</h3>
+                    <p class="text-slate-400 text-sm mb-4">Acesse e gerencie cadastros essenciais diretamente do dashboard.</p>
+                    <div class="space-y-3" id="dashboard-shortcuts">
+                        <button data-dashboard-shortcut data-target-view="cadastros-view" data-target-tab="equipes" class="w-full flex items-center justify-between bg-slate-700/60 hover:bg-slate-600 text-left px-4 py-3 rounded-lg transition-colors">
+                            <span class="flex items-center gap-2"><i data-lucide="users"></i> Equipes</span>
+                            <i data-lucide="arrow-up-right"></i>
+                        </button>
+                        <button data-dashboard-shortcut data-target-view="cadastros-view" data-target-tab="sistemas" class="w-full flex items-center justify-between bg-slate-700/60 hover:bg-slate-600 text-left px-4 py-3 rounded-lg transition-colors">
+                            <span class="flex items-center gap-2"><i data-lucide="cpu"></i> Sistemas</span>
+                            <i data-lucide="arrow-up-right"></i>
+                        </button>
+                        <button data-dashboard-shortcut data-target-view="cadastros-view" data-target-tab="clientes" class="w-full flex items-center justify-between bg-slate-700/60 hover:bg-slate-600 text-left px-4 py-3 rounded-lg transition-colors">
+                            <span class="flex items-center gap-2"><i data-lucide="building-2"></i> Clientes</span>
+                            <i data-lucide="arrow-up-right"></i>
+                        </button>
+                        <button data-dashboard-shortcut data-target-view="mensagens-view" data-action="trigger-button" data-target-button="add-mensagem-btn" class="w-full flex items-center justify-between bg-slate-700/60 hover:bg-slate-600 text-left px-4 py-3 rounded-lg transition-colors">
+                            <span class="flex items-center gap-2"><i data-lucide="message-circle"></i> Mensagens Personalizadas</span>
+                            <i data-lucide="arrow-up-right"></i>
+                        </button>
+                        <button data-dashboard-shortcut data-target-view="dashboard-view" data-action="trigger-button" data-target-button="add-project-btn" class="w-full flex items-center justify-between bg-slate-700/60 hover:bg-slate-600 text-left px-4 py-3 rounded-lg transition-colors">
+                            <span class="flex items-center gap-2"><i data-lucide="folder-plus"></i> Novo Projeto</span>
+                            <i data-lucide="arrow-up-right"></i>
+                        </button>
+                    </div>
                 </div>
             </section>
         </div>
@@ -174,6 +196,15 @@
         <!-- ########## VIEW: MENSAGENS ########## -->
         <div id="mensagens-view" data-view class="hidden">
             <header class="flex justify-between items-center mb-8"><h2 class="text-3xl font-bold text-white">Mensagens Personalizadas 💬</h2><button id="add-mensagem-btn" class="gradient-bg text-white font-semibold py-2 px-4 rounded-lg flex items-center gap-2"><i data-lucide="plus"></i> Nova Mensagem</button></header>
+            <section class="bg-[#1E2A47] p-6 rounded-xl mb-6">
+                <div class="flex items-start justify-between gap-4 flex-wrap">
+                    <div>
+                        <h3 class="text-xl font-bold text-white mb-1">Sugestões prontas para sua equipe</h3>
+                        <p class="text-sm text-slate-300 max-w-3xl">Escolha uma das mensagens recomendadas para iniciar conversas com o time. Ao enviar pelo WhatsApp, os marcadores <span class="font-semibold text-cyan-300">[NOME]</span> e <span class="font-semibold text-cyan-300">[EQUIPE]</span> serão substituídos automaticamente pelo nome do colaborador e da equipe.</p>
+                    </div>
+                </div>
+                <div id="message-suggestions" class="mt-4 grid grid-cols-1 lg:grid-cols-2 gap-4"></div>
+            </section>
             <section class="bg-[#1E2A47] p-6 rounded-xl"><table class="w-full text-left"><thead><tr class="border-b border-slate-700"><th class="p-3">Título</th><th class="p-3">Mensagem</th><th class="p-3 text-right">Ações</th></tr></thead><tbody id="mensagens-table-body"></tbody></table></section>
         </div>
 
@@ -218,8 +249,8 @@
     </main>
 
     <!-- Modal para Adicionar/Editar Projeto -->
-    <div id="project-modal" class="fixed inset-0 bg-black bg-opacity-80 flex justify-center items-start overflow-y-auto hidden z-50 p-4 pt-16">
-        <div class="bg-[#1E2A47] p-8 rounded-xl w-full max-w-7xl transform transition-all scale-95 opacity-0" id="project-modal-content">
+    <div id="project-modal" class="fixed inset-0 bg-black bg-opacity-80 flex justify-center items-center overflow-y-auto hidden z-50 p-4 pt-16">
+        <div class="bg-[#1E2A47] p-6 md:p-8 rounded-xl w-full max-w-5xl lg:max-w-6xl 2xl:max-w-7xl max-h-[85vh] overflow-y-auto transform transition-all scale-95 opacity-0" id="project-modal-content">
             <div class="flex justify-between items-center mb-6"><h3 id="project-modal-title" class="text-2xl font-bold"></h3><button id="close-modal-btn" class="text-slate-400"><i data-lucide="x-circle"></i></button></div>
             <form id="project-form">
                 <input type="hidden" id="projectId">
@@ -304,13 +335,76 @@
             let ideias = [];
             let knowledgeBase = [];
             let whatsappMessages = [];
+            const defaultMessageSuggestions = [
+                {
+                    id: 'suggestion-welcome',
+                    title: 'Boas-vindas ao projeto',
+                    text: 'Olá [NOME]! Bem-vindo(a) ao projeto. A equipe [EQUIPE] está pronta para apoiar você no que for preciso. Vamos juntos alcançar os resultados planejados?'
+                },
+                {
+                    id: 'suggestion-checkin',
+                    title: 'Check-in semanal',
+                    text: 'Oi [NOME], tudo bem? Passando para saber como estão as atividades dessa semana da equipe [EQUIPE]. Precisa de algum suporte extra?'
+                },
+                {
+                    id: 'suggestion-recognition',
+                    title: 'Reconhecimento de destaque',
+                    text: 'Parabéns [NOME]! O desempenho da equipe [EQUIPE] está chamando atenção. Continue assim, conte comigo para mantermos esse ritmo excelente.'
+                },
+                {
+                    id: 'suggestion-reminder',
+                    title: 'Lembrete de alinhamento',
+                    text: 'Olá [NOME], lembrando que amanhã teremos nosso alinhamento da equipe [EQUIPE]. Se precisar ajustar algo na pauta é só me avisar.'
+                }
+            ];
             let importContext = null;
 
             const importInput = document.getElementById('import-input');
 
             // --- LÓGICA DE RENDERIZAÇÃO ---
             let chartInstances = {};
-            
+
+            function normalizeProjectAssignments(project) {
+                if (!project || !Array.isArray(project.equipe)) return [];
+                const projectSystems = Array.isArray(project.sistemasIds) ? project.sistemasIds.filter(Boolean) : [];
+
+                return project.equipe.map(entry => {
+                    if (!entry) return null;
+
+                    if (typeof entry === 'string') {
+                        return { memberId: entry, sistemasIds: [] };
+                    }
+
+                    if (typeof entry === 'object') {
+                        const memberId = entry.memberId || entry.id || entry.member || entry.colaboradorId;
+                        let sistemasIds = [];
+
+                        if (Array.isArray(entry.sistemasIds)) {
+                            sistemasIds = entry.sistemasIds.filter(Boolean);
+                        } else if (Array.isArray(entry.sistemas)) {
+                            sistemasIds = entry.sistemas.filter(Boolean);
+                        } else if (Array.isArray(entry.modulos)) {
+                            sistemasIds = entry.modulos.filter(Boolean);
+                        } else if (entry.sistemaId) {
+                            sistemasIds = [entry.sistemaId];
+                        }
+
+                        const validIds = sistemasIds.filter(id => projectSystems.includes(id) || sistemas.some(s => s.id === id));
+                        return memberId ? { memberId, sistemasIds: Array.from(new Set(validIds)) } : null;
+                    }
+
+                    return null;
+                }).filter(Boolean);
+            }
+
+            function isModuleAllowedForMember(member, sistema) {
+                if (!sistema) return false;
+                const skills = Array.isArray(member?.skills) ? member.skills.filter(Boolean) : [];
+                if (skills.length === 0) return true;
+                const sistemaName = normalizeComparisonText(sistema.nome);
+                return skills.some(skill => sistemaName.includes(normalizeComparisonText(skill)));
+            }
+
             function getStatusPill(statusId) {
                  const status = statuses.find(s => s.id === statusId) || { text: 'N/A', color: '#808080' };
                 const emojis = { Planejamento: '⏳', Execução: '🟡', Homologação: '🟠', Risco: '❗', Concluído: '✅' };
@@ -335,6 +429,10 @@
             function sanitizeText(value) {
                 if (value === undefined || value === null) return '';
                 return String(value).trim();
+            }
+
+            function normalizeComparisonText(value) {
+                return (value || '').toString().normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
             }
 
             function normalizeNumericString(value) {
@@ -383,6 +481,7 @@
                     const config = [
                         { field: 'nome', keys: ['nome', 'name'], defaultIndex: 0 },
                         { field: 'cargo', keys: ['função', 'funcao', 'cargo', 'role'], defaultIndex: 1 },
+                        { field: 'teamName', keys: ['equipe', 'time', 'squad', 'tribo'] },
                         { field: 'email', keys: ['e-mail', 'email'], defaultIndex: 2 },
                         { field: 'telefone', keys: ['telefone', 'phone', 'celular', 'whatsapp'], defaultIndex: 3 },
                     ];
@@ -391,11 +490,13 @@
                         const cargo = sanitizeText(values.cargo);
                         if (!nome || !cargo) return null;
                         const email = sanitizeText(values.email);
+                        const teamName = sanitizeText(values.teamName);
                         const telefone = normalizeNumericString(values.telefone);
                         return {
                             id: generateUniqueId('TM'),
                             nome,
                             cargo,
+                            teamName,
                             email,
                             telefone,
                             avatar: generateAvatarInitials(nome),
@@ -454,10 +555,55 @@
                 return imported.length;
             }
 
+            function ensureProjectsHaveAssignmentsStructure() {
+                projects.forEach((project, index) => {
+                    if (!project || typeof project !== 'object') return;
+                    const normalizedEquipe = normalizeProjectAssignments(project);
+                    projects[index].equipe = normalizedEquipe;
+                });
+            }
+
+            function renderMessageSuggestions() {
+                const container = document.getElementById('message-suggestions');
+                if (!container) return;
+                container.innerHTML = '';
+
+                defaultMessageSuggestions.forEach(suggestion => {
+                    const alreadySaved = whatsappMessages.some(msg => msg.text.trim() === suggestion.text.trim());
+                    const highlightedText = suggestion.text.replace(/\[(NOME|EQUIPE)\]/g, '<span class="text-cyan-300 font-semibold">[$1]</span>');
+                    container.innerHTML += `
+                        <div class="bg-slate-800/60 border border-slate-700 rounded-lg p-4 flex flex-col justify-between">
+                            <div>
+                                <h4 class="text-lg font-semibold text-white">${suggestion.title}</h4>
+                                <p class="text-sm text-slate-300 mt-2 leading-relaxed">${highlightedText}</p>
+                            </div>
+                            <button data-action="use-suggestion" data-suggestion-id="${suggestion.id}" class="mt-4 self-start px-4 py-2 rounded-lg text-sm font-semibold transition-colors ${alreadySaved ? 'bg-slate-700 text-slate-400 cursor-not-allowed' : 'gradient-bg text-white'}" ${alreadySaved ? 'disabled' : ''}>${alreadySaved ? 'Mensagem adicionada' : 'Adicionar à lista personalizada'}</button>
+                        </div>`;
+                });
+            }
+
+            function handleSuggestionSelection(suggestionId) {
+                const suggestion = defaultMessageSuggestions.find(item => item.id === suggestionId);
+                if (!suggestion) return;
+                const alreadySaved = whatsappMessages.some(msg => msg.text.trim() === suggestion.text.trim());
+                if (alreadySaved) {
+                    alert('Esta mensagem já está disponível na sua lista personalizada.');
+                    return;
+                }
+                whatsappMessages.push({ id: generateUniqueId('MSG'), title: suggestion.title, text: suggestion.text });
+                renderWhatsappMessages();
+                renderMessageSuggestions();
+                lucide.createIcons();
+                alert('Mensagem adicionada à sua lista personalizada!');
+            }
+
             function renderAll() {
+                ensureProjectsHaveAssignmentsStructure();
                 renderProjects(); renderTeam(); renderSistemas(); renderClientes(); renderStatuses();
                 renderReports(); updateKPIs(); analyzeDataForAI(); renderIdeias();
                 renderWhatsappMessages();
+                renderMessageSuggestions();
+                setupDashboardShortcuts();
                 lucide.createIcons();
             }
 
@@ -484,7 +630,8 @@
                         </tr>`;
                     tableBody.innerHTML += tableRowHTML;
                     
-                    const responsaveisHTML = (p.equipe || []).map(assignment => {
+                    const assignments = normalizeProjectAssignments(p);
+                    const responsaveisHTML = assignments.map(assignment => {
                         const member = teamMembers.find(m => m.id === assignment.memberId);
                         if (!member) return '';
                         const assignedSistemas = (assignment.sistemasIds || []).map(sId => {
@@ -492,9 +639,9 @@
                             return `<span class="text-xs bg-slate-600 px-2 py-1 rounded-full whitespace-nowrap">${sistema?.nome || 'N/A'}</span>`;
                         }).join(' ');
 
-                        return `<div class="flex items-center gap-2 text-sm">
-                                    <div title="${member.nome}" class="w-7 h-7 rounded-full bg-blue-800 flex items-center justify-center text-xs font-bold ring-2 ring-slate-600 flex-shrink-0">${member.avatar}</div>
-                                    <div class="flex flex-wrap gap-1">${assignedSistemas}</div>
+                        return `<div class="space-y-1 text-sm">
+                                    <div class="font-semibold text-slate-100">${member.nome}</div>
+                                    <div class="flex flex-wrap gap-1">${assignedSistemas || '<span class="text-xs text-slate-500">Nenhum módulo atribuído.</span>'}</div>
                                 </div>`;
                     }).join('');
 
@@ -518,8 +665,10 @@
                     container.innerHTML += `<div class="bg-[#1E2A47] p-5 rounded-xl card-hover-effect text-center flex flex-col justify-between">
                         <div>
                             <div class="w-20 h-20 rounded-full bg-gradient-to-br from-cyan-400 to-blue-600 mx-auto flex items-center justify-center text-3xl font-bold mb-4">${m.avatar}</div>
-                            <h4 class="font-bold text-lg">${m.nome}</h4><p class="text-blue-300 text-sm mb-3">${m.cargo}</p>
-                            <div class="flex flex-wrap justify-center gap-2">${(m.skills || []).map(s => `<span class="bg-slate-700 text-slate-300 text-xs px-2.5 py-1 rounded-full">${s}</span>`).join('')}</div>
+                            <h4 class="font-bold text-lg">${m.nome}</h4>
+                            <p class="text-blue-300 text-sm">${m.cargo}</p>
+                            ${m.teamName ? `<p class=\"text-slate-400 text-xs uppercase tracking-wide mt-1\">Equipe ${m.teamName}</p>` : ''}
+                            <div class="flex flex-wrap justify-center gap-2 mt-3">${(m.skills || []).map(s => `<span class="bg-slate-700 text-slate-300 text-xs px-2.5 py-1 rounded-full">${s}</span>`).join('')}</div>
                         </div>
                         <div class="border-t border-slate-700 mt-4 pt-4 flex justify-center gap-4">
                             <button data-type="whatsapp" data-id="${m.id}" title="WhatsApp" class="text-green-400 hover:text-green-300"><i data-lucide="message-square"></i></button>
@@ -630,31 +779,6 @@
                 });
             }
             
-            function renderGamification() {
-                const container = document.getElementById('gamification-container');
-                if(!container) return;
-                container.innerHTML = '';
-                const nonManagers = teamMembers.filter(m => m.cargo && !m.cargo.toLowerCase().includes('gerente'));
-                const scores = nonManagers.map(member => {
-                    const completedProjects = projects.filter(p => p.equipe.some(e => e.memberId === member.id) && p.statusId === 'ST5');
-                    const score = completedProjects.length * 10;
-                    return { name: member.nome, score: score, avatar: member.avatar };
-                });
-
-                scores.sort((a, b) => b.score - a.score).forEach((item, index) => {
-                    const medals = ['🥇', '🥈', '🥉'];
-                    container.innerHTML += `<div class="flex items-center justify-between p-2 rounded-lg hover:bg-slate-800">
-                        <div class="flex items-center gap-3">
-                            <span class="font-bold text-lg w-8 text-center">${medals[index] || index + 1}</span>
-                            <div class="w-8 h-8 rounded-full bg-blue-800 flex items-center justify-center text-xs font-bold">${item.avatar}</div>
-                            <span>${item.name}</span>
-                        </div>
-                        <span class="font-bold text-cyan-400">${item.score} pts</span>
-                    </div>`;
-                });
-            }
-
-
             // --- LÓGICA GERAL DE MODAIS ---
             function openGenericModal(modalElement) { modalElement.classList.remove('hidden'); setTimeout(() => modalElement.querySelector('div:first-child').classList.remove('scale-95', 'opacity-0'), 10); }
             function closeGenericModal(modalElement) { modalElement.querySelector('div:first-child').classList.add('scale-95', 'opacity-0'); setTimeout(() => modalElement.classList.add('hidden'), 300); }
@@ -684,9 +808,9 @@
                 const id = document.getElementById('projectId').value;
                 
                 const equipe = [];
-                document.querySelectorAll('#module-assignment-container select').forEach(select => {
-                    const memberId = select.dataset.memberId;
-                    const sistemasIds = Array.from(select.selectedOptions).map(opt => opt.value);
+                document.querySelectorAll('#module-assignment-container [data-member-assignment]').forEach(wrapper => {
+                    const memberId = wrapper.dataset.memberId;
+                    const sistemasIds = Array.from(wrapper.querySelectorAll('[data-role="assigned-chip"]')).map(chip => chip.dataset.sistemaId);
                     if (sistemasIds.length > 0) {
                         equipe.push({ memberId, sistemasIds });
                     }
@@ -779,46 +903,227 @@
                 container.addEventListener('change', () => updateModuleAssignmentUI());
             }
 
+            function formatAssignmentCountLabel(count) {
+                if (!count) return 'Nenhum módulo selecionado';
+                return `${count} módulo${count === 1 ? '' : 's'}`;
+            }
+
+            function refreshMemberAssignmentCount(wrapper) {
+                if (!wrapper) return;
+                const countSpan = wrapper.querySelector('[data-role="assignment-count"]');
+                if (!countSpan) return;
+                const total = wrapper.querySelectorAll('[data-role="assigned-chip"]').length;
+                countSpan.textContent = formatAssignmentCountLabel(total);
+            }
+
+            function refreshAllMemberAssignmentCounts(container) {
+                if (!container) return;
+                container.querySelectorAll('[data-member-assignment]').forEach(wrapper => refreshMemberAssignmentCount(wrapper));
+            }
+
+            function getSelectedProjectSystemIds() {
+                return Array.from(document.querySelectorAll('#sistemas-tags-container .sistema-tag')).map(tag => tag.dataset.id);
+            }
+
+            function ensureAssignedListHasContent(wrapper) {
+                const list = wrapper.querySelector('[data-role="assigned-list"]');
+                if (!list) return;
+                if (list.querySelector('[data-role="assigned-chip"]')) {
+                    const emptyState = list.querySelector('[data-role="empty-state"]');
+                    if (emptyState) emptyState.remove();
+                } else if (!list.querySelector('[data-role="empty-state"]')) {
+                    const emptyMessage = document.createElement('span');
+                    emptyMessage.dataset.role = 'empty-state';
+                    emptyMessage.className = 'text-xs text-slate-500';
+                    emptyMessage.textContent = 'Nenhum módulo atribuído.';
+                    list.appendChild(emptyMessage);
+                }
+            }
+
+            function createModuleChipElement(sistemaId) {
+                const sistema = sistemas.find(s => s.id === sistemaId);
+                if (!sistema) return null;
+                const chip = document.createElement('span');
+                chip.dataset.role = 'assigned-chip';
+                chip.dataset.sistemaId = sistemaId;
+                chip.className = 'sistema-chip flex items-center gap-2 bg-cyan-500/20 text-cyan-200 px-3 py-1 rounded-full text-sm';
+                chip.innerHTML = `<span>${sistema.nome}</span><button type="button" data-action="remove-member-module" class="leading-none"><i data-lucide="x" class="w-4 h-4"></i></button>`;
+                return chip;
+            }
+
+            function updateModulePickerOptions(wrapper) {
+                if (!wrapper) return;
+                const picker = wrapper.querySelector('select[data-role="module-picker"]');
+                const hint = wrapper.querySelector('[data-role="available-hint"]');
+                if (!picker) return;
+
+                const assignedIds = Array.from(wrapper.querySelectorAll('[data-role="assigned-chip"]')).map(chip => chip.dataset.sistemaId);
+                const memberId = wrapper.dataset.memberId;
+                const member = teamMembers.find(m => m.id === memberId);
+                const projectSystemIds = getSelectedProjectSystemIds();
+                const allowedIds = projectSystemIds.filter(id => {
+                    const sistema = sistemas.find(s => s.id === id);
+                    return sistema && isModuleAllowedForMember(member, sistema);
+                });
+                const availableIds = allowedIds.filter(id => !assignedIds.includes(id));
+
+                picker.innerHTML = '<option value="">Adicionar módulo...</option>';
+                availableIds.forEach(id => {
+                    const sistema = sistemas.find(s => s.id === id);
+                    if (!sistema) return;
+                    const option = document.createElement('option');
+                    option.value = id;
+                    option.textContent = sistema.nome;
+                    picker.appendChild(option);
+                });
+
+                picker.value = '';
+                picker.disabled = availableIds.length === 0;
+                picker.classList.toggle('opacity-50', availableIds.length === 0);
+                if (hint) {
+                    if (availableIds.length === 0) {
+                        hint.textContent = allowedIds.length === 0 ? 'Nenhum módulo compatível com as habilidades cadastradas.' : 'Todos os módulos compatíveis já foram atribuídos para este membro.';
+                        hint.classList.remove('hidden');
+                    } else {
+                        hint.classList.add('hidden');
+                    }
+                }
+            }
+
             function updateModuleAssignmentUI(project = null) {
                 const assignmentContainer = document.getElementById('module-assignment-container');
                 if(!assignmentContainer) return;
-                const selectedSistemasIds = Array.from(document.querySelectorAll('#sistemas-tags-container .sistema-tag')).map(tag => tag.dataset.id);
-                const selectedTeamCheckboxes = document.querySelectorAll('#equipe-checkboxes input:checked');
+
+                const selectedSistemasIds = getSelectedProjectSystemIds();
+                const selectedTeamCheckboxes = Array.from(document.querySelectorAll('#equipe-checkboxes input:checked'));
+
                 const existingAssignments = {};
-                document.querySelectorAll('#module-assignment-container select[data-member-id]').forEach(select => {
-                    existingAssignments[select.dataset.memberId] = Array.from(select.selectedOptions).map(opt => opt.value);
+                assignmentContainer.querySelectorAll('[data-member-assignment]').forEach(wrapper => {
+                    const memberId = wrapper.dataset.memberId;
+                    existingAssignments[memberId] = Array.from(wrapper.querySelectorAll('[data-role="assigned-chip"]')).map(chip => chip.dataset.sistemaId);
                 });
+
                 assignmentContainer.innerHTML = '';
 
-                if (selectedSistemasIds.length === 0 || selectedTeamCheckboxes.length === 0) {
-                    assignmentContainer.innerHTML = '<p class="text-slate-500 text-sm">Adicione sistemas e selecione membros da equipe para definir responsabilidades.</p>';
+                if (selectedTeamCheckboxes.length === 0) {
+                    assignmentContainer.innerHTML = '<p class="text-slate-500 text-sm">Selecione membros da equipe para distribuir os módulos disponíveis.</p>';
                     return;
                 }
 
+                if (selectedSistemasIds.length === 0) {
+                    assignmentContainer.innerHTML = '<p class="text-slate-500 text-sm">Adicione sistemas ao projeto para escolher os módulos de cada membro.</p>';
+                    return;
+                }
+
+                const projectAssignments = project ? normalizeProjectAssignments(project) : [];
+
                 selectedTeamCheckboxes.forEach(cb => {
                     const member = teamMembers.find(m => m.id === cb.value);
+                    if (!member) return;
+
                     let selectedSystemsForMember = [];
-                    if (project && project.equipe) {
-                        const assignment = project.equipe.find(e => e.memberId === member.id);
-                        if (assignment) selectedSystemsForMember = assignment.sistemasIds;
+                    if (project) {
+                        const assignment = projectAssignments.find(e => e.memberId === member.id);
+                        if (assignment) selectedSystemsForMember = assignment.sistemasIds.filter(id => selectedSistemasIds.includes(id));
                     } else if (existingAssignments[member.id]) {
                         selectedSystemsForMember = existingAssignments[member.id].filter(id => selectedSistemasIds.includes(id));
                     }
 
-                    const selectOptionsHTML = selectedSistemasIds.map(sId => {
-                        const sistema = sistemas.find(s => s.id === sId);
-                        const isSelected = selectedSystemsForMember.includes(sistema.id) ? 'selected' : '';
-                        return `<option value="${sistema.id}" ${isSelected}>${sistema.nome}</option>`;
-                    }).join('');
+                    selectedSystemsForMember = Array.from(new Set(selectedSystemsForMember)).filter(id => {
+                        const sistema = sistemas.find(s => s.id === id);
+                        return sistema && isModuleAllowedForMember(member, sistema);
+                    });
 
-                    assignmentContainer.innerHTML += `
-                        <div class="grid grid-cols-3 items-center gap-4">
-                            <label class="text-slate-300 col-span-1">${member.nome}</label>
-                            <select multiple data-member-id="${member.id}" class="col-span-2 bg-slate-700 p-2 rounded-lg border border-slate-600 h-24">
-                                ${selectOptionsHTML}
-                            </select>
-                        </div>`;
+                    const wrapper = document.createElement('div');
+                    wrapper.className = 'space-y-3 border border-slate-700 rounded-lg p-4';
+                    wrapper.dataset.memberAssignment = 'true';
+                    wrapper.dataset.memberId = member.id;
+
+                    const header = document.createElement('div');
+                    header.className = 'flex items-center justify-between gap-3 flex-wrap';
+                    const memberInfo = document.createElement('div');
+                    memberInfo.innerHTML = `<span class="text-slate-200 font-semibold">${member.nome}</span>${member.teamName ? `<div class="text-xs text-slate-500">Equipe ${member.teamName}</div>` : ''}`;
+                    const countSpan = document.createElement('span');
+                    countSpan.dataset.role = 'assignment-count';
+                    countSpan.className = 'text-xs text-slate-400';
+                    header.appendChild(memberInfo);
+                    header.appendChild(countSpan);
+                    wrapper.appendChild(header);
+
+                    const assignedList = document.createElement('div');
+                    assignedList.className = 'flex flex-wrap gap-2';
+                    assignedList.dataset.role = 'assigned-list';
+                    selectedSystemsForMember.forEach(id => {
+                        const chip = createModuleChipElement(id);
+                        if (chip) assignedList.appendChild(chip);
+                    });
+                    wrapper.appendChild(assignedList);
+                    ensureAssignedListHasContent(wrapper);
+
+                    const controls = document.createElement('div');
+                    controls.className = 'flex flex-wrap gap-2 items-center';
+                    controls.innerHTML = `<select data-role="module-picker" class="bg-slate-800 text-slate-200 rounded-lg p-2 flex-grow min-w-[200px]"></select><p data-role="available-hint" class="text-xs text-slate-500 hidden">Todos os módulos selecionados já foram atribuídos para este membro.</p>`;
+                    wrapper.appendChild(controls);
+
+                    assignmentContainer.appendChild(wrapper);
+                    refreshMemberAssignmentCount(wrapper);
+                    updateModulePickerOptions(wrapper);
                 });
+
+                lucide.createIcons();
+            }
+
+            const moduleAssignmentContainer = document.getElementById('module-assignment-container');
+            if (moduleAssignmentContainer && !moduleAssignmentContainer.dataset.listenerAttached) {
+                moduleAssignmentContainer.addEventListener('change', event => {
+                    if (event.target.matches('select[data-role="module-picker"]')) {
+                        const select = event.target;
+                        const value = select.value;
+                        if (!value) return;
+                        const wrapper = select.closest('[data-member-assignment]');
+                        if (!wrapper) return;
+                        const list = wrapper.querySelector('[data-role="assigned-list"]');
+                        if (!list) return;
+                        if (list.querySelector(`[data-role="assigned-chip"][data-sistema-id="${value}"]`)) {
+                            select.value = '';
+                            return;
+                        }
+                        const chip = createModuleChipElement(value);
+                        if (!chip) return;
+                        const emptyState = list.querySelector('[data-role="empty-state"]');
+                        if (emptyState) emptyState.remove();
+                        list.appendChild(chip);
+                        select.value = '';
+                        refreshMemberAssignmentCount(wrapper);
+                        updateModulePickerOptions(wrapper);
+                        ensureAssignedListHasContent(wrapper);
+                        lucide.createIcons();
+                    }
+                });
+                moduleAssignmentContainer.addEventListener('click', event => {
+                    const removeBtn = event.target.closest('[data-action="remove-member-module"]');
+                    if (!removeBtn) return;
+                    const chip = removeBtn.closest('[data-role="assigned-chip"]');
+                    const wrapper = removeBtn.closest('[data-member-assignment]');
+                    if (!chip || !wrapper) return;
+                    chip.remove();
+                    ensureAssignedListHasContent(wrapper);
+                    refreshMemberAssignmentCount(wrapper);
+                    updateModulePickerOptions(wrapper);
+                });
+                moduleAssignmentContainer.dataset.listenerAttached = 'true';
+            }
+
+            const messageSuggestionsContainer = document.getElementById('message-suggestions');
+            if (messageSuggestionsContainer && !messageSuggestionsContainer.dataset.listenerAttached) {
+                messageSuggestionsContainer.addEventListener('click', event => {
+                    const button = event.target.closest('[data-action="use-suggestion"]');
+                    if (!button) return;
+                    const { suggestionId } = button.dataset;
+                    if (!suggestionId) return;
+                    handleSuggestionSelection(suggestionId);
+                });
+                messageSuggestionsContainer.dataset.listenerAttached = 'true';
             }
             
             function renderKanban(project) {
@@ -923,13 +1228,13 @@
                 
                 modalTitle.textContent = mode === 'add' ? `Adicionar ${type.charAt(0).toUpperCase() + type.slice(1)}` : `Editar ${type.charAt(0).toUpperCase() + type.slice(1)}`;
 
-                if (type === 'team') formContent.innerHTML = `<div><label>Nome</label><input name="nome" value="${item.nome || ''}" class="w-full bg-slate-700 p-2.5 rounded-lg" required></div><div><label>Cargo</label><input name="cargo" value="${item.cargo || ''}" class="w-full bg-slate-700 p-2.5 rounded-lg" required></div><div><label>E-mail</label><input type="email" name="email" value="${item.email || ''}" class="w-full bg-slate-700 p-2.5 rounded-lg"></div><div><label>Telefone (com DDI, ex: 5534...)</label><input type="tel" name="telefone" value="${item.telefone || ''}" class="w-full bg-slate-700 p-2.5 rounded-lg"></div><div><label>Habilidades (separadas por vírgula)</label><input name="skills" value="${(item.skills || []).join(', ')}" class="w-full bg-slate-700 p-2.5 rounded-lg"></div>`;
+                if (type === 'team') formContent.innerHTML = `<div><label>Nome</label><input name="nome" value="${item.nome || ''}" class="w-full bg-slate-700 p-2.5 rounded-lg" required></div><div><label>Cargo</label><input name="cargo" value="${item.cargo || ''}" class="w-full bg-slate-700 p-2.5 rounded-lg" required></div><div><label>Nome da Equipe</label><input name="teamName" value="${item.teamName || ''}" class="w-full bg-slate-700 p-2.5 rounded-lg" placeholder="Ex.: Squad Financeiro"></div><div><label>E-mail</label><input type="email" name="email" value="${item.email || ''}" class="w-full bg-slate-700 p-2.5 rounded-lg"></div><div><label>Telefone (com DDI, ex: 5534...)</label><input type="tel" name="telefone" value="${item.telefone || ''}" class="w-full bg-slate-700 p-2.5 rounded-lg"></div><div><label>Habilidades (separadas por vírgula)</label><input name="skills" value="${(item.skills || []).join(', ')}" class="w-full bg-slate-700 p-2.5 rounded-lg"></div>`;
                 if (type === 'sistema') formContent.innerHTML = `<div><label>Nome do Sistema</label><input name="nome" value="${item.nome || ''}" class="w-full bg-slate-700 p-2.5 rounded-lg" required></div><div><label>Tipo</label><input name="tipo" value="${item.tipo || ''}" class="w-full bg-slate-700 p-2.5 rounded-lg" required></div>`;
                 if (type === 'cliente') formContent.innerHTML = `<div><label>Nome do Cliente</label><input name="nome" value="${item.nome || ''}" class="w-full bg-slate-700 p-2.5 rounded-lg" required></div><div><label>Cidade</label><input name="cidade" value="${item.cidade || ''}" class="w-full bg-slate-700 p-2.5 rounded-lg" required></div><div><label>Responsável</label><input name="responsavel" value="${item.responsavel || ''}" class="w-full bg-slate-700 p-2.5 rounded-lg" required></div>`;
                 if (type === 'status') formContent.innerHTML = `<div><label>Nome do Status</label><input name="text" value="${item.text || ''}" class="w-full bg-slate-700 p-2.5 rounded-lg" required></div><div><label>Cor</label><input name="color" type="color" value="${item.color || '#64748B'}" class="w-full h-10 p-1 bg-slate-700 rounded-lg"></div>`;
                 if (type === 'ideia') formContent.innerHTML = `<div><label>Título da Ideia</label><input name="titulo" value="${item.titulo || ''}" class="w-full bg-slate-700 p-2.5 rounded-lg" required></div><div><label>Categoria</label><input name="categoria" value="${item.categoria || ''}" class="w-full bg-slate-700 p-2.5 rounded-lg"></div><div><label>Descrição</label><textarea name="descricao" rows="4" class="w-full bg-slate-700 p-2.5 rounded-lg">${item.descricao || ''}</textarea></div><div><label>Status</label><select name="status" class="w-full bg-slate-700 p-2.5 rounded-lg"><option>Nova</option><option>Em Análise</option><option>Aprovada</option><option>Rejeitada</option></select></div>`;
                 if (type === 'kb') formContent.innerHTML = `<div><label>Título do Artigo</label><input name="titulo" value="${item.titulo || ''}" class="w-full bg-slate-700 p-2.5 rounded-lg" required></div><div><label>Categoria</label><input name="categoria" value="${item.categoria || ''}" class="w-full bg-slate-700 p-2.5 rounded-lg"></div><div><label>Conteúdo</label><textarea name="conteudo" rows="6" class="w-full bg-slate-700 p-2.5 rounded-lg">${item.conteudo || ''}</textarea></div>`;
-                if (type === 'mensagem') formContent.innerHTML = `<div><label>Título da Mensagem</label><input name="title" value="${item.title || ''}" class="w-full bg-slate-700 p-2.5 rounded-lg" required></div><div><label>Texto da Mensagem</label><textarea name="text" rows="4" class="w-full bg-slate-700 p-2.5 rounded-lg" placeholder="Use [NOME] para o nome do destinatário.">${item.text || ''}</textarea></div>`;
+                if (type === 'mensagem') formContent.innerHTML = `<div><label>Título da Mensagem</label><input name="title" value="${item.title || ''}" class="w-full bg-slate-700 p-2.5 rounded-lg" required></div><div><label>Texto da Mensagem</label><textarea name="text" rows="4" class="w-full bg-slate-700 p-2.5 rounded-lg" placeholder="Use [NOME] para o nome do destinatário e [EQUIPE] para o nome da equipe.">${item.text || ''}</textarea></div>`;
 
                 openGenericModal(editModal);
             }
@@ -945,11 +1250,12 @@
                     else arr.push({ ...itemData, id: type.charAt(0).toUpperCase() + Date.now().toString().slice(-4) });
                 };
 
-                if (type === 'team') { 
-                    data.skills = data.skills.split(',').map(s=>s.trim()).filter(Boolean); 
+                if (type === 'team') {
+                    data.teamName = (data.teamName || '').trim();
+                    data.skills = (data.skills || '').split(',').map(s=>s.trim()).filter(Boolean);
                     data.avatar = generateAvatarInitials(data.nome);
-                    data.telefone = data.telefone.replace(/\D/g,''); 
-                    updateOrAdd(teamMembers, data); 
+                    data.telefone = (data.telefone || '').replace(/\D/g,'');
+                    updateOrAdd(teamMembers, data);
                 }
                 if (type === 'sistema') updateOrAdd(sistemas, data);
                 if (type === 'cliente') updateOrAdd(clientes, data);
@@ -981,8 +1287,10 @@
                         
                         const obsContainer = document.getElementById('observacoes-container');
                         obsContainer.innerHTML = project.observacoes.map(obs => `<div class="text-xs bg-slate-800 p-2 rounded"><p>${obs.text}</p><p class="text-slate-400 text-right">${new Date(obs.date).toLocaleString('pt-BR')}</p></div>`).join('') || '<p class="text-xs text-slate-500">Nenhuma observação.</p>';
-                        
-                        const projectTeamIds = project.equipe.map(e => e.memberId);
+
+                        const normalizedAssignments = normalizeProjectAssignments(project);
+                        project.equipe = normalizedAssignments;
+                        const projectTeamIds = normalizedAssignments.map(e => e.memberId);
                         populateManagerSelects(project.gerTec, project.gerCom);
                         populateSistemasSelect('sistemas-select-add');
                         renderSistemasTags('sistemas-tags-container', project.sistemasIds);
@@ -1036,6 +1344,40 @@
             });
             
             // --- LÓGICA DE NAVEGAÇÃO E TABS ---
+            function navigateToView(viewId) {
+                if (!viewId) return;
+                const navLink = document.querySelector(`aside nav a[data-target="${viewId}"]`);
+                if (navLink) {
+                    navLink.click();
+                } else {
+                    document.querySelectorAll('main > div[data-view]').forEach(view => view.classList.add('hidden'));
+                    document.getElementById(viewId)?.classList.remove('hidden');
+                }
+            }
+
+            function setupDashboardShortcuts() {
+                document.querySelectorAll('[data-dashboard-shortcut]').forEach(button => {
+                    if (button.dataset.initialized) return;
+                    button.dataset.initialized = 'true';
+                    button.addEventListener('click', () => {
+                        const { targetView, targetTab, action, targetButton } = button.dataset;
+                        if (targetView) {
+                            navigateToView(targetView);
+                        }
+                        if (targetTab) {
+                            setTimeout(() => {
+                                document.querySelector(`.tab-link[data-tab="${targetTab}"]`)?.click();
+                            }, 60);
+                        }
+                        if (action === 'trigger-button' && targetButton) {
+                            setTimeout(() => {
+                                document.getElementById(targetButton)?.click();
+                            }, 120);
+                        }
+                    });
+                });
+            }
+
             document.querySelectorAll('aside nav a').forEach(link => {
                 link.addEventListener('click', e => {
                     e.preventDefault();
@@ -1072,7 +1414,7 @@
                 newOkBtn.addEventListener('click', () => { callback(); closeGenericModal(confirmModal); });
             }
             document.getElementById('confirm-cancel-btn').addEventListener('click', () => closeGenericModal(confirmModal));
-            
+
             // --- WHATSAPP MODAL ---
             const whatsappModal = document.getElementById('whatsapp-modal');
             document.getElementById('close-whatsapp-modal-btn').addEventListener('click', () => closeGenericModal(whatsappModal));
@@ -1088,7 +1430,11 @@
                         btn.className = 'w-full text-left p-3 bg-slate-700 hover:bg-slate-600 rounded-lg';
                         btn.innerHTML = `<div class="font-bold">${msg.title}</div><p class="text-sm text-slate-400 truncate">${msg.text}</p>`;
                         btn.onclick = () => {
-                            const messageText = msg.text.replace(/\[NOME\]/g, member.nome.split(' ')[0]);
+                            const firstName = (member.nome || '').split(' ')[0] || member.nome;
+                            const teamName = member.teamName || 'sua equipe';
+                            const messageText = msg.text
+                                .replace(/\[NOME\]/g, firstName)
+                                .replace(/\[EQUIPE\]/g, teamName);
                             const url = `https://wa.me/${member.telefone}?text=${encodeURIComponent(messageText)}`;
                             window.open(url, '_blank');
                             closeGenericModal(whatsappModal);
@@ -1187,6 +1533,7 @@
 
 
             // --- INICIALIZAÇÃO ---
+            setupDashboardShortcuts();
             document.querySelector('[data-target="dashboard-view"]').click();
             renderAll();
             setInterval(analyzeDataForAI, 10000);


### PR DESCRIPTION
## Summary
- surface ready-to-use WhatsApp message suggestions in the personalized messages screen with automatic placeholder guidance
- save curated suggestions into the existing message list with personalized replacements for member and team names
- redesign module assignment in the project modal to use chip selections filtered by each member's skills and show full responsible names on project cards

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ccc8f32a948328935239a386aeaa08