### PR TITLE
Move quick management menu below deployment tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,8 +162,8 @@
                 </div>
             </section>
             
-            <section class="grid grid-cols-1 lg:grid-cols-3 gap-8">
-                <div class="lg:col-span-2 bg-[#1E2A47] p-6 rounded-xl">
+            <section class="space-y-8">
+                <div class="bg-[#1E2A47] p-6 rounded-xl">
                     <h3 class="text-xl font-bold mb-4">Acompanhamento de Implantações</h3>
                     <div class="overflow-x-auto"><table class="w-full text-left"><thead><tr class="border-b border-slate-700"><th class="p-3">Cliente / Projeto</th><th class="p-3">Status</th><th class="p-3">Progresso</th><th class="p-3">Detalhes</th><th class="p-3">Ações</th></tr></thead><tbody id="projects-table-body"></tbody></table></div>
                 </div>


### PR DESCRIPTION
## Summary
- stack the deployment tracking and quick management sections vertically on the dashboard
- ensure the quick management panel now appears below the deployment tracking table

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4625a06188328aa0efdf0a8371061