### PR TITLE
Add contract metadata fields and searchable selectors

### DIFF
--- a/index.html
+++ b/index.html
@@ -280,9 +280,13 @@
                             <div><label class="block mb-2 text-sm">Data de Início</label><input type="date" id="dataInicio" class="w-full bg-slate-700 p-2.5 rounded-lg" required></div>
                             <div><label class="block mb-2 text-sm">Previsão de Conclusão</label><input type="date" id="dataPrevisao" class="w-full bg-slate-700 p-2.5 rounded-lg" required></div>
                             <div><label class="block mb-2 text-sm">Ger. Comercial</label><select id="ger-comercial" class="w-full bg-slate-700 p-2.5 rounded-lg" required></select></div>
-                            <div><label class="block mb-2 text-sm">Ger. Técnica</label><select id="ger-tecnica" class="w-full bg-slate-700 p-2.5 rounded-lg" required></select></div>
+                            <div><label class="block mb-2 text-sm">Ger. Técnico</label><select id="ger-tecnica" class="w-full bg-slate-700 p-2.5 rounded-lg" required></select></div>
                             <div><label class="block mb-2 text-sm">Status</label><select id="status-select" class="w-full bg-slate-700 p-2.5 rounded-lg" required></select></div>
                             <div><label class="block mb-2 text-sm">Progresso (%)</label><input type="number" id="progresso" class="w-full bg-slate-700 p-2.5 rounded-lg" required min="0" max="100"></div>
+                            <div><label class="block mb-2 text-sm">Número do Contrato</label><input type="text" id="contrato-numero" class="w-full bg-slate-700 p-2.5 rounded-lg" placeholder="Ex.: 123/2024"></div>
+                            <div><label class="block mb-2 text-sm">Tempo de Vigência do Contrato</label><input type="text" id="contrato-vigencia" class="w-full bg-slate-700 p-2.5 rounded-lg" placeholder="Ex.: 12 meses"></div>
+                            <div><label class="block mb-2 text-sm">Termo de Aditivo Contratual</label><input type="text" id="aditivo-termo" class="w-full bg-slate-700 p-2.5 rounded-lg" placeholder="Descrição ou número do termo"></div>
+                            <div><label class="block mb-2 text-sm">Validade do Aditivo</label><input type="date" id="aditivo-validade" class="w-full bg-slate-700 p-2.5 rounded-lg"></div>
                         </div>
                         <div>
                             <label class="block mb-2 text-sm">Sistemas a Implantar</label>
@@ -354,6 +358,7 @@
             let ideias = [];
             let knowledgeBase = [];
             let whatsappMessages = [];
+            const searchableSelects = new Map();
             const normalizeText = (text) => typeof text === 'string' ? text.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase() : '';
             const escapeHTML = (text) => typeof text === 'string' ? text
                 .replace(/&/g, '&amp;')
@@ -517,19 +522,30 @@
             function fixEncodingIssues(text) {
                 if (!text) return '';
                 const cleaned = text.replace(/\uFEFF/g, '');
-                if (!/[ÃÂÊÔÕãõâêôàèìòùÁÉÍÓÚáéíóúçÇ]/.test(cleaned)) {
+                const needsFix = /[ÃÂÊÔÕãõâêô]/.test(cleaned);
+                if (!needsFix) {
                     return cleaned;
                 }
                 try {
-                    if (typeof TextDecoder === 'undefined') {
-                        return cleaned;
+                    if (typeof TextDecoder !== 'undefined') {
+                        const bytes = Uint8Array.from(cleaned.split('').map(char => char.charCodeAt(0)));
+                        const decoded = new TextDecoder('utf-8').decode(bytes);
+                        if (decoded && !/[ÃÂ]/.test(decoded) && !decoded.includes('\uFFFD')) {
+                            return decoded;
+                        }
                     }
-                    const bytes = Uint8Array.from(cleaned.split('').map(char => char.charCodeAt(0)));
-                    const decoded = new TextDecoder('utf-8').decode(bytes);
-                    return decoded || cleaned;
                 } catch (error) {
-                    return cleaned;
+                    console.warn('Falha ao normalizar texto com TextDecoder:', error);
                 }
+                try {
+                    if (typeof escape === 'function' && typeof decodeURIComponent === 'function') {
+                        const decoded = decodeURIComponent(escape(cleaned));
+                        if (decoded) return decoded;
+                    }
+                } catch (error) {
+                    console.warn('Falha ao normalizar texto via escape/decodeURIComponent:', error);
+                }
+                return cleaned;
             }
 
             function sanitizeText(value) {
@@ -570,8 +586,12 @@
                         let value = '';
                         if (hasHeader) {
                             const index = headerRow.findIndex(headerCell => item.keys.includes(headerCell));
-                            if (index !== -1) value = row[index];
-                        } else if (typeof item.defaultIndex === 'number') {
+                            if (index !== -1) {
+                                value = row[index];
+                            } else if (typeof item.defaultIndex === 'number' && item.defaultIndex < row.length) {
+                                value = row[item.defaultIndex];
+                            }
+                        } else if (typeof item.defaultIndex === 'number' && item.defaultIndex < row.length) {
                             value = row[item.defaultIndex];
                         }
                         values[item.field] = value;
@@ -820,6 +840,10 @@
                     const moduleSummaryBadges = ((p.sistemasIds || []).map(sId => formatModuleBadge(sId)).filter(Boolean).join(' ')) || '<span class="text-xs text-slate-500">Nenhum módulo cadastrado.</span>';
                     const gerenteComercial = teamMembers.find(tm => tm.id === p.gerCom)?.nome || 'Não atribuído';
                     const gerenteTecnico = teamMembers.find(tm => tm.id === p.gerTec)?.nome || 'Não atribuído';
+                    const numeroContrato = sanitizeText(p.numeroContrato) || 'Não informado';
+                    const vigenciaContrato = sanitizeText(p.vigenciaContrato) || 'Não informado';
+                    const aditivoTermo = sanitizeText(p.aditivoTermo) || 'Não informado';
+                    const aditivoValidade = formatDateForDisplay(p.aditivoValidade) || 'Não informado';
                     const equipeResumo = assignments.length
                         ? assignments.map(assignment => {
                             const member = teamMembers.find(m => m.id === assignment.memberId);
@@ -840,7 +864,13 @@
                             </div>
                             <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
                                 <div class="text-xs text-slate-400 uppercase tracking-wide">Ger. Comercial<div class="text-sm text-slate-200 normal-case tracking-normal">${gerenteComercial}</div></div>
-                                <div class="text-xs text-slate-400 uppercase tracking-wide">Ger. Técnica<div class="text-sm text-slate-200 normal-case tracking-normal">${gerenteTecnico}</div></div>
+                                <div class="text-xs text-slate-400 uppercase tracking-wide">Ger. Técnico<div class="text-sm text-slate-200 normal-case tracking-normal">${gerenteTecnico}</div></div>
+                            </div>
+                            <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                                <div class="text-xs text-slate-400 uppercase tracking-wide">Nº do Contrato<div class="text-sm text-slate-200 normal-case tracking-normal">${numeroContrato}</div></div>
+                                <div class="text-xs text-slate-400 uppercase tracking-wide">Vigência<div class="text-sm text-slate-200 normal-case tracking-normal">${vigenciaContrato}</div></div>
+                                <div class="text-xs text-slate-400 uppercase tracking-wide sm:col-span-2">Termo Aditivo<div class="text-sm text-slate-200 normal-case tracking-normal">${aditivoTermo}</div></div>
+                                <div class="text-xs text-slate-400 uppercase tracking-wide">Validade do Aditivo<div class="text-sm text-slate-200 normal-case tracking-normal">${aditivoValidade}</div></div>
                             </div>
                             <div>
                                 <p class="text-xs uppercase tracking-wide text-slate-400">Equipe responsável</p>
@@ -882,6 +912,12 @@
                             <div class="flex justify-between items-start mb-4"><div class="pr-8"><h4 class="font-bold text-lg">${cliente?.nome}</h4><p class="text-sm text-slate-400">${projectSistemas}</p></div>${getStatusPill(p.statusId)}</div>
                             <div class="mb-4"><div class="text-right text-sm mt-1 mb-1">${p.progresso}%</div><div class="w-full bg-slate-600 rounded-full h-2.5"><div class="bg-gradient-to-r from-cyan-400 to-blue-500 h-2.5 rounded-full" style="width: ${p.progresso}%"></div></div></div>
                             <div class="text-xs text-slate-400 flex justify-between mb-4"><span>Início: ${new Date(p.dataInicio).toLocaleDateString()}</span><span>Previsão: ${new Date(p.dataPrevisao).toLocaleDateString()}</span></div>
+                            <div class="text-xs text-slate-400 space-y-1 mb-4">
+                                <div>Contrato: <span class="text-slate-200">${numeroContrato}</span></div>
+                                <div>Vigência: <span class="text-slate-200">${vigenciaContrato}</span></div>
+                                <div>Termo Aditivo: <span class="text-slate-200">${aditivoTermo}</span></div>
+                                <div>Validade do Aditivo: <span class="text-slate-200">${aditivoValidade}</span></div>
+                            </div>
                          </div>
                         <div class="border-t border-slate-700 pt-4"><p class="text-sm text-slate-400 mb-2">Responsáveis:</p><div class="space-y-3">${responsaveisHTML || '<p class="text-xs text-slate-500">Nenhum responsável atribuído.</p>'}</div></div>
                         <div class="absolute top-4 right-4 flex flex-col gap-2"><button class="edit-btn" data-type="project" data-id="${p.id}"><i data-lucide="edit" class="text-cyan-400"></i></button><button class="delete-btn" data-type="project" data-id="${p.id}"><i data-lucide="trash-2" class="text-red-400"></i></button></div>
@@ -1066,9 +1102,13 @@
                 const projectData = {
                     clienteId: document.getElementById('cliente-select').value, cidade: document.getElementById('cidade').value,
                     gerTec: document.getElementById('ger-tecnica').value, gerCom: document.getElementById('ger-comercial').value,
-                    sistemasIds: Array.from(document.querySelectorAll('#sistemas-tags-container .sistema-tag')).map(tag => tag.dataset.id), 
+                    sistemasIds: Array.from(document.querySelectorAll('#sistemas-tags-container .sistema-tag')).map(tag => tag.dataset.id),
                     progresso: parseInt(document.getElementById('progresso').value), statusId: document.getElementById('status-select').value,
                     dataInicio: document.getElementById('dataInicio').value, dataPrevisao: document.getElementById('dataPrevisao').value,
+                    numeroContrato: document.getElementById('contrato-numero').value.trim(),
+                    vigenciaContrato: document.getElementById('contrato-vigencia').value.trim(),
+                    aditivoTermo: document.getElementById('aditivo-termo').value.trim(),
+                    aditivoValidade: document.getElementById('aditivo-validade').value,
                     equipe: equipe
                 };
                 const novaObservacao = document.getElementById('nova-observacao').value.trim();
@@ -1086,6 +1126,74 @@
                 closeGenericModal(projectModal);
             });
             
+            function enhanceSelectWithSearch(selectId, placeholder = 'Digite para buscar...') {
+                const select = document.getElementById(selectId);
+                if (!select || select.dataset.searchEnhanced === 'true') return;
+
+                const searchInput = document.createElement('input');
+                searchInput.type = 'search';
+                searchInput.placeholder = placeholder;
+                searchInput.className = 'w-full bg-slate-800 border border-slate-700 rounded-lg py-2 px-3 text-sm text-slate-200 focus:outline-none focus:ring-2 focus:ring-cyan-400 mb-2';
+                searchInput.dataset.role = 'select-search-input';
+                searchInput.id = `${selectId}-search`;
+
+                select.parentNode.insertBefore(searchInput, select);
+
+                const relatedLabel = select.parentNode.querySelector('label');
+                if (relatedLabel && !relatedLabel.getAttribute('for')) {
+                    relatedLabel.setAttribute('for', searchInput.id);
+                }
+
+                const container = select.parentNode;
+                if (container && !container.dataset.searchWrapperEnhanced) {
+                    container.addEventListener('click', event => {
+                        if (event.target === container) {
+                            searchInput.focus();
+                        }
+                    });
+                    container.dataset.searchWrapperEnhanced = 'true';
+                }
+
+                const filterOptions = () => {
+                    const normalizedTerm = normalizeComparisonText(searchInput.value || '');
+                    let firstMatchValue = '';
+
+                    Array.from(select.options).forEach(option => {
+                        if (!option.value) {
+                            option.hidden = normalizedTerm.length > 0;
+                            return;
+                        }
+
+                        const matches = normalizeComparisonText(option.text).includes(normalizedTerm);
+                        option.hidden = normalizedTerm.length > 0 && !matches;
+
+                        if (!firstMatchValue && matches) {
+                            firstMatchValue = option.value;
+                        }
+                    });
+
+                    if (normalizedTerm && firstMatchValue) {
+                        if (select.value !== firstMatchValue) {
+                            select.value = firstMatchValue;
+                            select.dispatchEvent(new Event('change', { bubbles: true }));
+                        }
+                    }
+
+                    if (!normalizedTerm) {
+                        Array.from(select.options).forEach(option => option.hidden = false);
+                    }
+                };
+
+                searchInput.addEventListener('input', filterOptions);
+                searchInput.addEventListener('keydown', event => {
+                    if (event.key === 'Enter') event.preventDefault();
+                });
+                searchInput.addEventListener('focus', () => filterOptions());
+
+                select.dataset.searchEnhanced = 'true';
+                searchableSelects.set(selectId, { searchInput, filterOptions });
+            }
+
             function populateSelect(selectId, data, valueField, textField, selectedValue = '') {
                 const select = document.getElementById(selectId);
                 if(!select) return;
@@ -1093,26 +1201,38 @@
                 data.forEach(item => {
                     select.innerHTML += `<option value="${item[valueField]}" ${item[valueField] == selectedValue ? 'selected' : ''}>${item[textField]}</option>`;
                 });
+                const enhancement = searchableSelects.get(selectId);
+                if (enhancement) {
+                    enhancement.filterOptions();
+                }
             }
-            function populateManagerSelects(selectedGerTec = '', selectedGerCom = '') { 
-                const gerentesTecnicos = teamMembers.filter(m => m.cargo && m.cargo.toLowerCase().includes('gerente técn'));
-                const gerentesComerciais = teamMembers.filter(m => m.cargo && m.cargo.toLowerCase().includes('gerente comer'));
-                populateSelect('ger-tecnica', gerentesTecnicos, 'id', 'nome', selectedGerTec); 
-                populateSelect('ger-comercial', gerentesComerciais, 'id', 'nome', selectedGerCom); 
+            function populateManagerSelects(selectedGerTec = '', selectedGerCom = '') {
+                const gerentesTecnicos = teamMembers.filter(m => {
+                    const cargo = normalizeComparisonText(m.cargo);
+                    return cargo.includes('gerente tecn');
+                });
+                const gerentesComerciais = teamMembers.filter(m => {
+                    const cargo = normalizeComparisonText(m.cargo);
+                    return cargo.includes('gerente comer');
+                });
+                populateSelect('ger-tecnica', gerentesTecnicos, 'id', 'nome', selectedGerTec);
+                populateSelect('ger-comercial', gerentesComerciais, 'id', 'nome', selectedGerCom);
             }
-            function populateClientesSelect(selectedClienteId = '') { 
+            function populateClientesSelect(selectedClienteId = '') {
                 const select = document.getElementById('cliente-select');
                 if(!select) return;
                 select.innerHTML = '<option value="">Selecione...</option>';
                 clientes.forEach(item => {
                     select.innerHTML += `<option value="${item.id}" ${item.id == selectedClienteId ? 'selected' : ''}>${item.nome}</option>`;
                 });
-                select.addEventListener('change', (e) => {
+                select.onchange = (e) => {
                     const selectedClient = clientes.find(c => c.id === e.target.value);
                     if(selectedClient) {
                         document.getElementById('cidade').value = selectedClient.cidade;
                     }
-                });
+                };
+                const enhancement = searchableSelects.get('cliente-select');
+                if (enhancement) enhancement.filterOptions();
             }
             function populateStatusSelect(selectedStatusId = '') { populateSelect('status-select', statuses, 'id', 'text', selectedStatusId); }
             function populateSistemasSelect(selectId) { populateSelect(selectId, sistemas, 'id', 'nome');}
@@ -1138,21 +1258,95 @@
                 lucide.createIcons();
             }
             
+            function filterTeamCheckboxes(listContainer, term = '', emptyState = null) {
+                if (!listContainer) return;
+                const normalizedTerm = normalizeComparisonText(term || '');
+                let visibleCount = 0;
+                listContainer.querySelectorAll('label').forEach(label => {
+                    const source = label.dataset.searchValue || '';
+                    const matches = !normalizedTerm || source.includes(normalizedTerm);
+                    label.classList.toggle('hidden', !matches);
+                    if (matches) visibleCount++;
+                });
+                if (emptyState) {
+                    emptyState.classList.toggle('hidden', visibleCount > 0);
+                }
+            }
+
             function populateTeamCheckboxes(containerId, selectedMemberIds = []) {
                 const container = document.getElementById(containerId);
                 if(!container) return;
-                const nonManagers = teamMembers.filter(m => m.cargo && !m.cargo.toLowerCase().includes('gerente'));
-                container.innerHTML = '';
-                nonManagers.forEach(item => {
-                    const checked = selectedMemberIds.includes(item.id) ? 'checked' : '';
-                    container.innerHTML += `<label class="flex items-center gap-2 p-2 rounded hover:bg-slate-700 cursor-pointer"><input type="checkbox" value="${item.id}" ${checked} class="w-4 h-4 text-cyan-400 bg-gray-700 border-gray-600 rounded focus:ring-cyan-500"><span>${item.nome}</span></label>`;
+                const nonManagers = teamMembers.filter(m => {
+                    const cargo = normalizeComparisonText(m.cargo);
+                    return !cargo.includes('gerente');
                 });
-                container.addEventListener('change', () => updateModuleAssignmentUI());
+
+                let searchInput = container.querySelector('input[data-role="team-search"]');
+                let listContainer = container.querySelector('[data-role="team-list"]');
+                let emptyState = container.querySelector('[data-role="team-empty"]');
+
+                if (!listContainer) {
+                    container.innerHTML = '';
+
+                    const searchWrapper = document.createElement('div');
+                    searchWrapper.className = 'mb-3';
+                    searchInput = document.createElement('input');
+                    searchInput.type = 'search';
+                    searchInput.placeholder = 'Digite para buscar membro...';
+                    searchInput.className = 'w-full bg-slate-800 border border-slate-700 rounded-lg py-2 px-3 text-sm text-slate-200 focus:outline-none focus:ring-2 focus:ring-cyan-400';
+                    searchInput.dataset.role = 'team-search';
+                    searchWrapper.appendChild(searchInput);
+                    container.appendChild(searchWrapper);
+
+                    listContainer = document.createElement('div');
+                    listContainer.dataset.role = 'team-list';
+                    listContainer.className = 'space-y-2 max-h-60 overflow-y-auto pr-1';
+                    container.appendChild(listContainer);
+
+                    emptyState = document.createElement('p');
+                    emptyState.dataset.role = 'team-empty';
+                    emptyState.className = 'text-sm text-slate-500 hidden';
+                    emptyState.textContent = 'Nenhum membro encontrado.';
+                    container.appendChild(emptyState);
+
+                    searchInput.addEventListener('input', () => filterTeamCheckboxes(listContainer, searchInput.value, emptyState));
+
+                    if (!container.dataset.changeHandlerAttached) {
+                        listContainer.addEventListener('change', () => updateModuleAssignmentUI());
+                        container.dataset.changeHandlerAttached = 'true';
+                    }
+                } else {
+                    listContainer.innerHTML = '';
+                }
+
+                nonManagers.forEach(item => {
+                    const wrapper = document.createElement('label');
+                    wrapper.className = 'flex items-center gap-2 p-2 rounded hover:bg-slate-700 cursor-pointer';
+                    wrapper.dataset.searchValue = normalizeComparisonText(item.nome);
+                    wrapper.innerHTML = `<input type="checkbox" value="${item.id}" ${selectedMemberIds.includes(item.id) ? 'checked' : ''} class="w-4 h-4 text-cyan-400 bg-gray-700 border-gray-600 rounded focus:ring-cyan-500"><span>${item.nome}</span>`;
+                    listContainer.appendChild(wrapper);
+                });
+
+                filterTeamCheckboxes(listContainer, searchInput ? searchInput.value : '', emptyState);
             }
+
+            [
+                { id: 'cliente-select', placeholder: 'Digite para buscar o cliente...' },
+                { id: 'ger-comercial', placeholder: 'Digite para buscar o gerente comercial...' },
+                { id: 'ger-tecnica', placeholder: 'Digite para buscar o gerente técnico...' },
+                { id: 'sistemas-select-add', placeholder: 'Digite para buscar o sistema...' },
+            ].forEach(({ id, placeholder }) => enhanceSelectWithSearch(id, placeholder));
 
             function formatAssignmentCountLabel(count) {
                 if (!count) return 'Nenhum módulo selecionado';
                 return `${count} módulo${count === 1 ? '' : 's'}`;
+            }
+
+            function formatDateForDisplay(value) {
+                if (!value) return '';
+                const date = new Date(value);
+                if (Number.isNaN(date.getTime())) return '';
+                return date.toLocaleDateString('pt-BR');
             }
 
             function refreshMemberAssignmentCount(wrapper) {
@@ -1560,7 +1754,11 @@
                         document.getElementById('progresso').value = project.progresso;
                         document.getElementById('dataInicio').value = project.dataInicio;
                         document.getElementById('dataPrevisao').value = project.dataPrevisao;
-                        
+                        document.getElementById('contrato-numero').value = project.numeroContrato || '';
+                        document.getElementById('contrato-vigencia').value = project.vigenciaContrato || '';
+                        document.getElementById('aditivo-termo').value = project.aditivoTermo || '';
+                        document.getElementById('aditivo-validade').value = project.aditivoValidade || '';
+
                         const obsContainer = document.getElementById('observacoes-container');
                         obsContainer.innerHTML = project.observacoes.map(obs => `<div class="text-xs bg-slate-800 p-2 rounded"><p>${obs.text}</p><p class="text-slate-400 text-right">${new Date(obs.date).toLocaleString('pt-BR')}</p></div>`).join('') || '<p class="text-xs text-slate-500">Nenhuma observação.</p>';
 


### PR DESCRIPTION
## Summary
- fix CSV import by improving encoding normalization and honoring column defaults so cargos are preserved
- add searchable helpers for client, manager, sistema selects and team checklist filtering
- extend project form and listings with contract metadata fields and update labeling for Ger. Técnico

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d4659502b08328b22de6d99895548c