### PR TITLE
Allow system badges to wrap within project cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -583,7 +583,7 @@
                 const sistema = sistemas.find(s => s.id === sistemaId);
                 if (!sistema) return '';
                 const compatible = member ? isModuleWithinSkills(member, sistema) : true;
-                const baseClasses = 'text-xs px-2 py-1 rounded-full whitespace-nowrap';
+                const baseClasses = 'text-xs px-2 py-1 rounded-full break-words leading-tight';
                 const styleClasses = compatible ? 'bg-slate-600 text-slate-200' : 'bg-amber-500/20 text-amber-200 border border-amber-400/30';
                 const label = compatible ? sistema.nome : `${sistema.nome} (*)`;
                 return `<span class="${baseClasses} ${styleClasses}">${label}</span>`;


### PR DESCRIPTION
## Summary
- allow project system badges to wrap onto multiple lines by updating badge base classes
- keep compatibility styling while improving text readability in narrow cards

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d48ed747b48328bcd8db448c7f1bec